### PR TITLE
fix dungeon level missing

### DIFF
--- a/common/constants/bonuses.js
+++ b/common/constants/bonuses.js
@@ -34,7 +34,10 @@ export const stats_bonus = {
   skill_taming: {
     1: { pet_luck: 1 },
   },
-  skill_dungeoneering: { 1: { health: 2 } },
+  skill_dungeoneering: {
+    1: { health: 2 },
+    51: { health: 0 },
+  },
   skill_social: {},
   skill_carpentry: {},
   skill_runecrafting: {},

--- a/public/resources/ts/calculate-player-stats.ts
+++ b/public/resources/ts/calculate-player-stats.ts
@@ -97,7 +97,7 @@ export function getPlayerStats() {
     const bonusStats: ItemStats = getBonusStat(
       calculated.dungeons.catacombs.level.level,
       "skill_dungeoneering",
-      Math.min(calculated.dungeons.catacombs.level.maxLevel, 50)
+      calculated.dungeons.catacombs.level.maxLevel
     );
 
     for (const [name, value] of Object.entries(bonusStats)) {

--- a/public/resources/ts/calculate-player-stats.ts
+++ b/public/resources/ts/calculate-player-stats.ts
@@ -93,11 +93,11 @@ export function getPlayerStats() {
   }
 
   // Dungeoneering stats
-  {
+  if (calculated.dungeons?.catacombs?.level?.level) {
     const bonusStats: ItemStats = getBonusStat(
-      calculated.dungeons?.catacombs?.level?.level ?? 0,
+      calculated.dungeons.catacombs.level.level,
       "skill_dungeoneering",
-      calculated.dungeons?.catacombs?.level?.maxLevel ?? 50
+      Math.min(calculated.dungeons.catacombs.level.maxLevel, 50)
     );
 
     for (const [name, value] of Object.entries(bonusStats)) {


### PR DESCRIPTION
Thought it's cleaner to just wrap everything inside an `if()` statement and also added future proofing for when we will support cata levels higher than 50, since 50 is still the max level at which players receive extra hp bonus

Still, this is **not tested**, please tell me in which profile JS fails cause I can't find any 😕 